### PR TITLE
Changes in hive and lib thirf

### DIFF
--- a/hive/src/main/java/com/twitter/elephantbird/mapred/input/HiveMultiInputFormat.java
+++ b/hive/src/main/java/com/twitter/elephantbird/mapred/input/HiveMultiInputFormat.java
@@ -47,7 +47,7 @@ public class HiveMultiInputFormat
     if (!"".equals(HiveConf.getVar(job, HiveConf.ConfVars.PLAN))) {
       // Running as a Hive query. Use MapredWork for metadata.
       Map<String, PartitionDesc> partitionDescMap =
-          Utilities.getMapRedWork(job).getPathToPartitionInfo();
+          Utilities.getMapWork(job).getPathToPartitionInfo();
 
       if (!partitionDescMap.containsKey(split.getPath().getParent().toUri().toString())) {
         throw new RuntimeException("Failed locating partition description for "

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <apache.pig.version>0.11.1</apache.pig.version>
     <apache.crunch.hadoop1.version>0.8.2</apache.crunch.hadoop1.version>
     <apache.crunch.hadoop2.version>0.8.2-hadoop2</apache.crunch.hadoop2.version>
-    <apache.hive.version>0.8.0</apache.hive.version>
+    <apache.hive.version>0.13.0</apache.hive.version>
     <apache.mahout.version>0.6</apache.mahout.version>
     <apache.lucene.version>4.0.0</apache.lucene.version>
     <protobuf.version>2.5.0</protobuf.version>
@@ -248,7 +248,7 @@
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>0.5.0-cdh</version>
+        <version>0.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.json-simple</groupId>
@@ -602,7 +602,7 @@
           <artifactId>maven-thrift-plugin</artifactId>
           <version>0.1.10</version>
           <configuration>
-            <thriftExecutable>/usr/local/bin/thrift-0.5</thriftExecutable>
+            <thriftExecutable>/usr/local/bin/thrift</thriftExecutable>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <apache.pig.version>0.11.1</apache.pig.version>
     <apache.crunch.hadoop1.version>0.8.2</apache.crunch.hadoop1.version>
     <apache.crunch.hadoop2.version>0.8.2-hadoop2</apache.crunch.hadoop2.version>
-    <apache.hive.version>0.13.0</apache.hive.version>
+    <apache.hive.version>0.13.3-inm</apache.hive.version>
     <apache.mahout.version>0.6</apache.mahout.version>
     <apache.lucene.version>4.0.0</apache.lucene.version>
     <protobuf.version>2.5.0</protobuf.version>


### PR DESCRIPTION
1- Hive version changed to 0.13.0
2- Lib thrift version chnaged to 0.8.0
3- Replaced getMapRedWork method with getMapWork in HiveMultiInputFormat
